### PR TITLE
fix: support multiline environment_data values

### DIFF
--- a/JSON.rst
+++ b/JSON.rst
@@ -89,7 +89,8 @@ A step contains the following properties:
 * ``container_url`` (URL, optional): A URL to a tarball containing the Docker
   image. If specified, Loads will download the image from this URL instead of
   the Docker Hub.
-* ``environment_data`` (Array or newline-separated string, optional):
+* ``environment_data`` (Object of key value pairs or Array or strings,
+  optional):
   Environment variables to use for this container. Subject to interpolation.
 * ``additional_command_args`` (String, optional): Additional arguments to pass
   to the container ``ENTRYPOINT``, or the full command name and arguments if

--- a/loadsbroker/broker.py
+++ b/loadsbroker/broker.py
@@ -61,7 +61,6 @@ from loadsbroker.extensions import (
     SSH,
     ContainerInfo,
 )
-from loadsbroker.util import parse_env
 from loadsbroker.webapp.api import _DEFAULTS
 
 import threading
@@ -650,14 +649,14 @@ class RunManager:
 
         # Startup the testers
         env = self.run_env.copy()
-        env.update(parse_env(setlink.step.environment_data))
+        env.update(setlink.step.environment_data)
         env['CONTAINER_ID'] = setlink.step.uuid
         logger.debug("Starting step: %s", setlink.ec2_collection.uuid)
         await self.helpers.docker.run_containers(
             setlink.ec2_collection,
-            container_name=setlink.step.container_name,
+            setlink.step.container_name,
+            setlink.step.additional_command_args,
             env=env,
-            command_args=setlink.step.additional_command_args,
             ports=setlink.step.port_mapping or {},
             volumes=setlink.step.volume_mapping or {},
             delay=setlink.step.node_delay,

--- a/loadsbroker/dockerctrl.py
+++ b/loadsbroker/dockerctrl.py
@@ -1,10 +1,18 @@
 """ Interacts with a Docker Daemon on a remote instance"""
 import random
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional
+)
 
 import docker
 from requests.exceptions import ConnectionError, Timeout
 
 from loadsbroker.util import retry
+
+StrDict = Dict[str, str]
 
 DOCKER_RETRY_EXC = (ConnectionError, Timeout)
 
@@ -102,8 +110,14 @@ class DockerDaemon:
         images = self._client.images(all=True)
         return any(container_name in image["RepoTags"] for image in images)
 
-    def run_container(self, container_name, env, command_args, volumes={},
-                      ports={}, dns=[], pid_mode=None):
+    def run_container(self,
+                      name: str,
+                      command: Optional[str] = None,
+                      env: Optional[StrDict] = None,
+                      volumes: Optional[Dict[str, StrDict]] = None,
+                      ports: Optional[Dict[Any, Any]] = None,
+                      dns: Optional[List[str]] = None,
+                      pid_mode: Optional[str] = None):
         """Run a container given the container name, env, command args, data
         volumes, and port bindings."""
 
@@ -119,7 +133,7 @@ class DockerDaemon:
             expose.append(port)
 
         result = self._client.create_container(
-            container_name, command=command_args, environment=env,
+            name, command=command, environment=env,
             volumes=[volume['bind'] for volume in volumes.values()],
             ports=expose)
 

--- a/loadsbroker/util.py
+++ b/loadsbroker/util.py
@@ -55,11 +55,6 @@ def retry(attempts=3,
     return __retry
 
 
-def parse_env(envstr):
-    """Parse a string of environ lines into a dict"""
-    return dict(line.split('=', maxsplit=1) for line in envstr.splitlines())
-
-
 def join_host_port(host, port):
     """Joins a host and port"""
     if ":" in host or "%" in host:


### PR DESCRIPTION
(like e.g. an entire TLS cert)

by persisting envs as JSON encoded dicts. allows them to be treated as
dicts everywhere

and some cleanup to the run methods (make envs optional)

issue #64